### PR TITLE
Fix error message when refreshing the games list if the save path doesn't exist…

### DIFF
--- a/AutoPBW.WPF/MainWindow.xaml.cs
+++ b/AutoPBW.WPF/MainWindow.xaml.cs
@@ -677,7 +677,10 @@ namespace AutoPBW.WPF
 									watcher.EnableRaisingEvents = true;
 								}
 							}
-							TurnUploadWatchers.Add(savepath, watcher);
+							if (watcher != null)
+							{
+								TurnUploadWatchers.Add(savepath, watcher);
+							}
 						}
 					}
 				}


### PR DESCRIPTION
…and we fail to create the turn file watcher. Once the savegame has been downloaded the watcher gets created successfully, and you can't play your turn without downloading the save, so it's a non-issue.