### PR TITLE
Fixing #30 False error when uploading PLR files

### DIFF
--- a/AutoPBW.WPF/MainWindow.xaml.cs
+++ b/AutoPBW.WPF/MainWindow.xaml.cs
@@ -681,7 +681,7 @@ namespace AutoPBW.WPF
 								{
 									watcher = new FileSystemWatcher(savepath, "*.plr");
 									watcher.Changed += OnTurnFileChanged;
-									watcher.NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size;
+									watcher.NotifyFilter = NotifyFilters.LastWrite;
 									watcher.EnableRaisingEvents = true;
 								}
 							}
@@ -730,6 +730,11 @@ namespace AutoPBW.WPF
 						{
 							game.UploadTurn();
 							anyUploaded = true;
+						}
+						catch (IOException ioex) when ((ioex.HResult & 0x0000FFFF) == 0x0020)
+						{
+							// Sharing violation - this means the game hasn't finished writing the file yet
+							// we can expect another filewatcher event when the file is closed by the game, so we can just ignore it for now
 						}
 						catch (Exception ex)
 						{

--- a/AutoPBW/Game.cs
+++ b/AutoPBW/Game.cs
@@ -395,10 +395,8 @@ namespace AutoPBW
 				throw new InvalidOperationException("Can only upload one PLR file at a time. " + files.Count() + " files were submitted.");
 
 			PBW.Log.Write($"Uploading player commands {path} for {this}.");
-			if (PBW.Upload(files.Single(), url, "plr_file"))
-				Status = PlayerStatus.Uploaded;
-			else
-				throw new WebException("Could not upload " + files.Single() + " to PBW. Try uploading it manually to see if there is an error.");
+			PBW.Upload(files.Single(), url, "plr_file");
+			Status = PlayerStatus.Uploaded;
 		}
 
 		public void PlayTurn()


### PR DESCRIPTION
#30 

Refactor PBW.Upload so it throws an exception when there's an error response from the API instead of returning false and relying on UploadTurn translating it into an exception.

Added a warning if the response is 200 OK when we expected something else, but don't treat it as an error

Fix errors when automatically uploading turns